### PR TITLE
mcom: Support boot from MMC2 on Salute-EL24PM1 board

### DIFF
--- a/board/elvees/common/board.c
+++ b/board/elvees/common/board.c
@@ -188,10 +188,11 @@ u32 spl_boot_mode(const u32 boot_device)
 {
 	switch (boot_device) {
 	case BOOT_DEVICE_MMC1:
+	case BOOT_DEVICE_MMC2:
 		return MMCSD_MODE_RAW;
 	}
 
-	return 0;
+	return MMCSD_MODE_UNDEFINED;
 }
 #endif
 

--- a/board/elvees/salute-pm/salute-pm.c
+++ b/board/elvees/salute-pm/salute-pm.c
@@ -88,4 +88,16 @@ int set_sdram_cfg(struct ddr_cfg *cfg, int tck)
 
 	return 0;
 }
+
+void board_boot_order(u32 *spl_boot_list)
+{
+  spl_boot_list[0] = spl_boot_device();
+
+  switch (spl_boot_list[0]) {
+  case BOOT_DEVICE_MMC1:
+    spl_boot_list[0] = BOOT_DEVICE_MMC1;
+    spl_boot_list[1] = BOOT_DEVICE_MMC2;
+    break;
+  }
+}
 #endif


### PR DESCRIPTION
This commit fixes SPL to conform the board manual,
that stated (2.8.5.2) that the boot sequence should proceed
from SDMMC0 to SDMMC1 in case of failure.

It will work only when CONFIG_SPL_RAW_IMAGE_SUPPORT=n.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
